### PR TITLE
feat: add custom resolution viewport with positioning options

### DIFF
--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -25,6 +25,14 @@ export default {
 			alias: {
 				'@renderer': resolve('src/renderer/src')
 			}
+		},
+		build: {
+			rollupOptions: {
+				input: {
+					index: resolve(__dirname, 'src/renderer/index.html'),
+					viewport: resolve(__dirname, 'src/renderer/viewport.html')
+				}
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "electron-kiosk",
-	"version": "0.10.1",
+	"version": "0.10.0",
 	"private": false,
 	"description": "Electron Kiosk",
 	"main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "electron-kiosk",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"private": false,
 	"description": "Electron Kiosk",
 	"main": "./out/main/index.js",

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -36,6 +36,89 @@
 									</v-switch>
 								</v-col>
 
+								<!-- Custom Resolution for Single Display -->
+								<v-col
+									v-if="!settings.multipleDisplays"
+									:cols="12"
+									:sm="6"
+								>
+									<v-switch
+										color="primary"
+										v-model="settings.useCustomResolution"
+										inset
+										label="Custom Resolution"
+										persistent-hint
+										hint="Simulate a specific resolution (e.g., 1024x768)"
+										class="ml-3"
+										@change="validateForm"
+									>
+									</v-switch>
+								</v-col>
+
+								<v-col
+									v-if="!settings.multipleDisplays && settings.useCustomResolution"
+									:cols="12"
+									:sm="3"
+								>
+									<v-text-field
+										v-model.number="settings.customWidth"
+										type="number"
+										label="Width"
+										hint="Resolution width in pixels"
+										persistent-hint
+										suffix="px"
+										min="320"
+										:rules="[
+											v => !!v || 'Width is required',
+											v => v >= 320 || 'Minimum width is 320px'
+										]"
+										@input="validateForm"
+										required
+									>
+									</v-text-field>
+								</v-col>
+
+								<v-col
+									v-if="!settings.multipleDisplays && settings.useCustomResolution"
+									:cols="12"
+									:sm="3"
+								>
+									<v-text-field
+										v-model.number="settings.customHeight"
+										type="number"
+										label="Height"
+										hint="Resolution height in pixels"
+										persistent-hint
+										suffix="px"
+										min="240"
+										:rules="[
+											v => !!v || 'Height is required',
+											v => v >= 240 || 'Minimum height is 240px'
+										]"
+										@input="validateForm"
+										required
+									>
+									</v-text-field>
+								</v-col>
+
+								<v-col
+									v-if="!settings.multipleDisplays && settings.useCustomResolution"
+									:cols="12"
+									:sm="6"
+								>
+									<v-select
+										v-model="settings.customPosition"
+										:items="positionOptions"
+										label="Position"
+										hint="Where to position the viewport on screen"
+										persistent-hint
+										item-title="label"
+										item-value="value"
+										@update:modelValue="validateForm"
+									>
+									</v-select>
+								</v-col>
+
 								<v-col
 									v-if="settings.multipleDisplays"
 									:cols="12"
@@ -88,6 +171,90 @@
 												</template>
 											</v-text-field>
 										</v-col>
+										
+										<!-- Custom Resolution per Display -->
+										<v-col :cols="12" :sm="4">
+											<v-switch
+												color="primary"
+												v-model="display.useCustomResolution"
+												inset
+												label="Custom Resolution"
+												persistent-hint
+												hint="Enable custom resolution for this display"
+												class="ml-3"
+												@change="validateForm"
+											>
+											</v-switch>
+										</v-col>
+
+										<v-col
+											v-if="display.useCustomResolution"
+											:cols="12"
+											:sm="3"
+										>
+											<v-text-field
+												v-model.number="display.customWidth"
+												type="number"
+												label="Width"
+												hint="Resolution width in pixels"
+												persistent-hint
+												suffix="px"
+												min="320"
+												:rules="[
+													v => !!v || 'Width is required',
+													v => v >= 320 || 'Minimum width is 320px'
+												]"
+												@input="validateForm"
+												required
+											>
+											</v-text-field>
+										</v-col>
+
+										<v-col
+											v-if="display.useCustomResolution"
+											:cols="12"
+											:sm="3"
+										>
+											<v-text-field
+												v-model.number="display.customHeight"
+												type="number"
+												label="Height"
+												hint="Resolution height in pixels"
+												persistent-hint
+												suffix="px"
+												min="240"
+												:rules="[
+													v => !!v || 'Height is required',
+													v => v >= 240 || 'Minimum height is 240px'
+												]"
+												@input="validateForm"
+												required
+											>
+											</v-text-field>
+										</v-col>
+
+										<v-col
+											v-if="display.useCustomResolution"
+											:cols="12"
+											:sm="2"
+										>
+											<v-select
+												v-model="display.customPosition"
+												:items="positionOptions"
+												label="Position"
+												hint="Where to position the viewport on screen"
+												persistent-hint
+												item-title="label"
+												item-value="value"
+												@update:modelValue="validateForm"
+											>
+											</v-select>
+										</v-col>
+
+										<!-- Divider between displays -->
+										<v-col v-if="index < settings.displays.length - 1" :cols="12">
+											<v-divider class="my-2"></v-divider>
+										</v-col>
 									</v-row>
 									<div class="d-flex">
 										<v-btn
@@ -100,7 +267,11 @@
 											@click="
 												settings.displays.push({
 													id: '',
-													url: ''
+													url: '',
+													useCustomResolution: false,
+													customWidth: 1920,
+													customHeight: 1080,
+													customPosition: 'top-left'
 												})
 											"
 										>
@@ -272,6 +443,17 @@ export default {
 			title: `${i < 10 ? '0' : ''}${i}:00`,
 			value: i
 		})),
+		positionOptions: [
+			{ label: 'Top Left', value: 'top-left' },
+			{ label: 'Top Center', value: 'top-center' },
+			{ label: 'Top Right', value: 'top-right' },
+			{ label: 'Center Left', value: 'center-left' },
+			{ label: 'Center', value: 'center' },
+			{ label: 'Center Right', value: 'center-right' },
+			{ label: 'Bottom Left', value: 'bottom-left' },
+			{ label: 'Bottom Center', value: 'bottom-center' },
+			{ label: 'Bottom Right', value: 'bottom-right' }
+		],
 		required: v => v != null || 'This is required'
 	}),
 	computed: {
@@ -323,6 +505,12 @@ export default {
 
 	methods: {
 		parse,
+		validateForm() {
+			// Trigger form validation
+			if (this.$refs.form) {
+				this.$refs.form.validate()
+			}
+		},
 		validDisplay(id) {
 			if (!this.displays.find(d => d.id === id)) {
 				return 'Invalid display'
@@ -376,8 +564,39 @@ export default {
 				})
 
 				this.urlReady = true
-				// redirect to url
-				window.location.href = url
+				
+				// Check if custom resolution is enabled
+				let useCustomResolution = false
+				let customWidth = 1920
+				let customHeight = 1080
+				let customPosition = 'top-left'
+
+				if (this.displayId) {
+					// Get settings for this specific display
+					const displaySetting = this.settings.displays.find(
+						d => d.id === this.displayId
+					)
+					if (displaySetting) {
+						useCustomResolution = displaySetting.useCustomResolution || false
+						customWidth = displaySetting.customWidth || 1920
+						customHeight = displaySetting.customHeight || 1080
+						customPosition = displaySetting.customPosition || 'top-left'
+					}
+				} else {
+					// Get global settings
+					useCustomResolution = this.settings.useCustomResolution || false
+					customWidth = this.settings.customWidth || 1920
+					customHeight = this.settings.customHeight || 1080
+					customPosition = this.settings.customPosition || 'top-left'
+				}
+
+				// Redirect to viewport wrapper or directly to URL
+				if (useCustomResolution) {
+					const viewportUrl = `viewport.html?url=${encodeURIComponent(url)}&width=${customWidth}&height=${customHeight}&position=${customPosition}`
+					window.location.href = viewportUrl
+				} else {
+					window.location.href = url
+				}
 			} catch (error) {
 				// noop
 			}

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -50,7 +50,6 @@
 										persistent-hint
 										hint="Simulate a specific resolution (e.g., 1024x768)"
 										class="ml-3"
-										@change="validateForm"
 									>
 									</v-switch>
 								</v-col>
@@ -72,7 +71,7 @@
 											v => !!v || 'Width is required',
 											v => v >= 320 || 'Minimum width is 320px'
 										]"
-										@input="validateForm"
+										
 										required
 									>
 									</v-text-field>
@@ -95,7 +94,7 @@
 											v => !!v || 'Height is required',
 											v => v >= 240 || 'Minimum height is 240px'
 										]"
-										@input="validateForm"
+										
 										required
 									>
 									</v-text-field>
@@ -114,7 +113,6 @@
 										persistent-hint
 										item-title="label"
 										item-value="value"
-										@update:modelValue="validateForm"
 									>
 									</v-select>
 								</v-col>
@@ -182,7 +180,6 @@
 												persistent-hint
 												hint="Enable custom resolution for this display"
 												class="ml-3"
-												@change="validateForm"
 											>
 											</v-switch>
 										</v-col>
@@ -204,7 +201,7 @@
 													v => !!v || 'Width is required',
 													v => v >= 320 || 'Minimum width is 320px'
 												]"
-												@input="validateForm"
+												
 												required
 											>
 											</v-text-field>
@@ -227,7 +224,7 @@
 													v => !!v || 'Height is required',
 													v => v >= 240 || 'Minimum height is 240px'
 												]"
-												@input="validateForm"
+												
 												required
 											>
 											</v-text-field>
@@ -246,7 +243,6 @@
 												persistent-hint
 												item-title="label"
 												item-value="value"
-												@update:modelValue="validateForm"
 											>
 											</v-select>
 										</v-col>
@@ -505,12 +501,6 @@ export default {
 
 	methods: {
 		parse,
-		validateForm() {
-			// Trigger form validation
-			if (this.$refs.form) {
-				this.$refs.form.validate()
-			}
-		},
 		validDisplay(id) {
 			if (!this.displays.find(d => d.id === id)) {
 				return 'Invalid display'

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -55,7 +55,7 @@
 								</v-col>
 
 								<v-col
-									v-if="!settings.multipleDisplays && settings.useCustomResolution"
+									v-show="!settings.multipleDisplays && settings.useCustomResolution"
 									:cols="12"
 									:sm="3"
 								>
@@ -78,7 +78,7 @@
 								</v-col>
 
 								<v-col
-									v-if="!settings.multipleDisplays && settings.useCustomResolution"
+									v-show="!settings.multipleDisplays && settings.useCustomResolution"
 									:cols="12"
 									:sm="3"
 								>
@@ -101,7 +101,7 @@
 								</v-col>
 
 								<v-col
-									v-if="!settings.multipleDisplays && settings.useCustomResolution"
+									v-show="!settings.multipleDisplays && settings.useCustomResolution"
 									:cols="12"
 									:sm="6"
 								>
@@ -185,7 +185,7 @@
 										</v-col>
 
 										<v-col
-											v-if="display.useCustomResolution"
+											v-show="display.useCustomResolution"
 											:cols="12"
 											:sm="3"
 										>
@@ -208,7 +208,7 @@
 										</v-col>
 
 										<v-col
-											v-if="display.useCustomResolution"
+											v-show="display.useCustomResolution"
 											:cols="12"
 											:sm="3"
 										>
@@ -231,7 +231,7 @@
 										</v-col>
 
 										<v-col
-											v-if="display.useCustomResolution"
+											v-show="display.useCustomResolution"
 											:cols="12"
 											:sm="2"
 										>

--- a/src/renderer/viewport.html
+++ b/src/renderer/viewport.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Viewport</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        html, body {
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+            background-color: #000;
+        }
+        
+        body {
+            display: flex;
+        }
+        
+        #viewport-frame {
+            border: none;
+            background-color: #fff;
+        }
+    </style>
+</head>
+<body>
+    <iframe id="viewport-frame"></iframe>
+    
+    <script>
+        // Get parameters from URL
+        const params = new URLSearchParams(window.location.search);
+        const targetUrl = params.get('url');
+        const width = params.get('width') || '1920';
+        const height = params.get('height') || '1080';
+        const position = params.get('position') || 'top-left';
+        
+        // Set iframe properties
+        const iframe = document.getElementById('viewport-frame');
+        iframe.src = targetUrl;
+        iframe.style.width = width + 'px';
+        iframe.style.height = height + 'px';
+        
+        // Apply positioning based on selection
+        const positionMap = {
+            'top-left': { alignItems: 'flex-start', justifyContent: 'flex-start' },
+            'top-center': { alignItems: 'flex-start', justifyContent: 'center' },
+            'top-right': { alignItems: 'flex-start', justifyContent: 'flex-end' },
+            'center-left': { alignItems: 'center', justifyContent: 'flex-start' },
+            'center': { alignItems: 'center', justifyContent: 'center' },
+            'center-right': { alignItems: 'center', justifyContent: 'flex-end' },
+            'bottom-left': { alignItems: 'flex-end', justifyContent: 'flex-start' },
+            'bottom-center': { alignItems: 'flex-end', justifyContent: 'center' },
+            'bottom-right': { alignItems: 'flex-end', justifyContent: 'flex-end' }
+        };
+        
+        const posStyles = positionMap[position] || positionMap['top-left'];
+        document.body.style.alignItems = posStyles.alignItems;
+        document.body.style.justifyContent = posStyles.justifyContent;
+        
+        // Handle iframe load errors
+        iframe.onerror = function() {
+            console.error('Failed to load URL in viewport:', targetUrl);
+        };
+    </script>
+</body>
+</html>

--- a/src/store.js
+++ b/src/store.js
@@ -31,9 +31,41 @@ const store = new Store({
 							url: {
 								type: 'string',
 								default: ''
+							},
+							useCustomResolution: {
+								type: 'boolean',
+								default: false
+							},
+							customWidth: {
+								type: 'number',
+								default: 1920
+							},
+							customHeight: {
+								type: 'number',
+								default: 1080
+							},
+							customPosition: {
+								type: 'string',
+								default: 'top-left'
 							}
 						}
 					}
+				},
+				useCustomResolution: {
+					type: 'boolean',
+					default: false
+				},
+				customWidth: {
+					type: 'number',
+					default: 1920
+				},
+				customHeight: {
+					type: 'number',
+					default: 1080
+				},
+				customPosition: {
+					type: 'string',
+					default: 'top-left'
 				},
 				dark: {
 					type: 'boolean',


### PR DESCRIPTION
This pr proposes the option to load page inside an iframe with fixed resolution, for those projects and installations where the final user viewport is smaller than the actual physical screen.
Resolves #23 

- Add custom resolution settings (global and per-display)
- Implement viewport.html with iframe for rendering sites at custom resolutions
- Add position selector (9 preset positions: top/center/bottom × left/center/right)
- Update UI with resolution controls and position picker
- Maintain fullscreen kiosk mode while rendering sites at specified dimensions
- Support independent resolution configuration for multiple displays