### PR TITLE
fix: fallback display label when empty on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 node_modules
 /dist
-
+/dist_*
 
 # local env files
 .env.local

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -275,10 +275,10 @@ function registerIpc() {
 					})
 					break
 				case 'getDisplays':
-					data = screen.getAllDisplays().map(display => {
+					data = screen.getAllDisplays().map((display, index) => {
 						return {
 							id: display.id,
-							label: display.label
+							label: display.label || `Display ${index + 1}`
 						}
 					})
 					break


### PR DESCRIPTION
## Problem

On Linux (and some other platforms), `display.label` returned by Electron's `screen.getAllDisplays()` can be an empty string. This caused the multiple-displays dropdown in the settings UI to show an option with no visible text.

## Fix

- **`src/main/index.js`**: Fall back to a generated label (`Display 1`, `Display 2`, …) when `display.label` is empty.
- **`.gitignore`**: Added `/dist_*` pattern to ignore all `dist_electron` and similar build output folders.